### PR TITLE
moved 'View' box (back) above the 'X-axis' box

### DIFF
--- a/src/som_page_handler.ml
+++ b/src/som_page_handler.ml
@@ -131,7 +131,9 @@ let t ~args = object (self)
     printf "<form name='optionsForm'>\n";
     printf "<table width=\"100%%\" border=\"0\">\n<tr><td>\n";
     self#write_som_info som_info;
+    printf "<div>";
     print_select_list ~label:"View" ~attrs:[("id", "view")] ["Graph"; "Table"];
+    printf "</div><br />\n";
     print_x_axis_choice ~conn config_columns som_configs_opt;
     print_y_axis_choice ~conn config_columns som_configs_opt;
     let checkbox name caption =


### PR DESCRIPTION
This is a relatively trivial change. You may have noticed that when the former header was moved up, the 'view' selection came down to where the 'xaxis' ad 'yaxis' selection boxes were. This makes it look the same as it did before. More importantly, this is important for the next pull request.