### PR TITLE
made auto_redraw off by default

### DIFF
--- a/static/rage.js
+++ b/static/rage.js
@@ -9,8 +9,8 @@ Invariants (also reflected on server side):
 */
 
 // === GLOBAL VARIABLES --- start ===
-var autofetch = true; // if false, the following triggers have no effect
-var checkboxes_on_by_default = ["show_points", "show_avgs", "y_fromto_zero", "auto_redraw"];
+var autofetch = false; // if false, the following triggers have no effect
+var checkboxes_on_by_default = ["show_points", "show_avgs", "y_fromto_zero"];
 var graph_only_fields = [
   "#xaxis", "#yaxis", "#show_points", "#show_avgs", "#show_dist",
   "#x_from_zero", "#y_fromto_zero", "#x_as_seq", "#y_as_seq", "#x_as_num", "#show_all_meta",


### PR DESCRIPTION
This is a great feature for three reasons:
1. It'll be much smoother if you ever start from scratch.
2. Because auto_redraw's on/off state will be saved in tinyURLs, it won't affect you when you return to an old URL.
3. It'll work nicely in conjunction with the "enabling auto_redraw will immediately redraw the graph" feature. 

None of your saved URLs will have auto_redraw enabled (the first time you load them), so you'll click on auto_redraw. Then you're back where you were, in that single click (it'll draw automatically). You'll save the new URL when you're done for the day, and when you come back auto_redraw will be enabled, as you left it. For people starting from scratch or developing rage, it'll be much nicer as well.