### PR TITLE
redraw button will say 'Draw' instead of 'Redraw' when auto_redraw is disabled

### DIFF
--- a/static/rage.js
+++ b/static/rage.js
@@ -240,9 +240,11 @@ function set_auto_redraw() {
   if (is_checked("auto_redraw")) {
     autofetch = true;
     fetch_data_and_process();
+    $("#redraw").prop('value', 'Redraw');
   }
   else {
     autofetch = false;
+    $("#redraw").prop('value', 'Draw');
   }
 }
 


### PR DESCRIPTION
When auto_redraw is off, it might make more sense to have the button say "Draw", since the graph is only drawing when the user clicks on this button.