### PR TITLE
graph_title is hidden until first graph drawn

### DIFF
--- a/static/rage.js
+++ b/static/rage.js
@@ -73,6 +73,7 @@ function som_page_init() {
   $(".multiselect").change(redraw_trigger);
   // fetch and process data immediately
   preselect_fields_based_on_params();
+  $("#graph_title").css('display','none'); //until a graph is drawn, the graph title should be hidden
   set_auto_redraw(); //will call fetch_data_and_process() if auto_redraw is enabled
   // extract image button
   load_get_image_if_not_ie();


### PR DESCRIPTION
When auto_redraw is off, the page will load with an empty graph_title box. The graph_title box is meant to hide if it is empty, but it wasn't hiding if the page had just loaded. This commit fixes that.