### PR TITLE
Add an option for a new zoomable graph

### DIFF
--- a/src/som_page_handler.ml
+++ b/src/som_page_handler.ml
@@ -175,6 +175,7 @@ let t ~args = object (self)
     printf "%s'toggle_filters' value='Hide Configuration' />" submit_prefix;
     printf "%s'stop_plotting' value='Stop Plotting' />" submit_prefix;
     printf "%s'redraw' value='Redraw' />" submit_prefix;
+    printf "<select id='graph_option' onchange='change_graph()'><option value='flot'>flot graph</option><option value='d3'>d3 graph</option></select>";
     printf "<img id='progress_img' src='progress.gif' />\n";
     printf "<br /><div class='graph_container'>";
     printf "<div class='yaxis'></div>";
@@ -182,5 +183,6 @@ let t ~args = object (self)
     printf "<div class='xaxis'></div>";
     printf "</div>";
     printf "<div id='table'></div>";
+    printf "<div id='graph1' class='chart'></div>";
     self#include_javascript;
 end

--- a/static/d3/d3_color.js
+++ b/static/d3/d3_color.js
@@ -1,0 +1,64 @@
+/* Plugin for jQuery for working with colors.
+ * 
+ * Version 1.1.
+ * 
+ * Inspiration from jQuery color animation plugin by John Resig.
+ *
+ * Released under the MIT license by Ole Laursen, October 2009.
+ *
+ * Examples:
+ *
+ *   $.color.parse("#fff").scale('rgb', 0.25).add('a', -0.5).toString()
+ *   var c = $.color.extract($("#mydiv"), 'background-color');
+ *   console.log(c.r, c.g, c.b, c.a);
+ *   $.color.make(100, 50, 25, 0.4).toString() // returns "rgba(100,50,25,0.4)"
+ *
+ * Note that .scale() and .add() return the same modified object
+ * instead of making a new one.
+ *
+ * V. 1.1: Fix error handling so e.g. parsing an empty string does
+ * produce a color rather than just crashing.
+ */ 
+
+(function(B){B.color={};B.color.make=function(F,E,C,D){var G={};G.r=F||0;G.g=E||0;G.b=C||0;G.a=D!=null?D:1;G.add=function(J,I){for(var H=0;H<J.length;++H){G[J.charAt(H)]+=I}return G.normalize()};G.scale=function(J,I){for(var H=0;H<J.length;++H){G[J.charAt(H)]*=I}return G.normalize()};G.toString=function(){if(G.a>=1){return"rgb("+[G.r,G.g,G.b].join(",")+")"}else{return"rgba("+[G.r,G.g,G.b,G.a].join(",")+")"}};G.normalize=function(){function H(J,K,I){return K<J?J:(K>I?I:K)}G.r=H(0,parseInt(G.r),255);G.g=H(0,parseInt(G.g),255);G.b=H(0,parseInt(G.b),255);G.a=H(0,G.a,1);return G};G.clone=function(){return B.color.make(G.r,G.b,G.g,G.a)};return G.normalize()};B.color.extract=function(D,C){var E;do{E=D.css(C).toLowerCase();if(E!=""&&E!="transparent"){break}D=D.parent()}while(!B.nodeName(D.get(0),"body"));if(E=="rgba(0, 0, 0, 0)"){E="transparent"}return B.color.parse(E)};B.color.parse=function(F){var E,C=B.color.make;if(E=/rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/.exec(F)){return C(parseInt(E[1],10),parseInt(E[2],10),parseInt(E[3],10))}if(E=/rgba\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*\)/.exec(F)){return C(parseInt(E[1],10),parseInt(E[2],10),parseInt(E[3],10),parseFloat(E[4]))}if(E=/rgb\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*\)/.exec(F)){return C(parseFloat(E[1])*2.55,parseFloat(E[2])*2.55,parseFloat(E[3])*2.55)}if(E=/rgba\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*\)/.exec(F)){return C(parseFloat(E[1])*2.55,parseFloat(E[2])*2.55,parseFloat(E[3])*2.55,parseFloat(E[4]))}if(E=/#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})/.exec(F)){return C(parseInt(E[1],16),parseInt(E[2],16),parseInt(E[3],16))}if(E=/#([a-fA-F0-9])([a-fA-F0-9])([a-fA-F0-9])/.exec(F)){return C(parseInt(E[1]+E[1],16),parseInt(E[2]+E[2],16),parseInt(E[3]+E[3],16))}var D=B.trim(F).toLowerCase();if(D=="transparent"){return C(255,255,255,0)}else{E=A[D]||[0,0,0];return C(E[0],E[1],E[2])}};var A={aqua:[0,255,255],azure:[240,255,255],beige:[245,245,220],black:[0,0,0],blue:[0,0,255],brown:[165,42,42],cyan:[0,255,255],darkblue:[0,0,139],darkcyan:[0,139,139],darkgrey:[169,169,169],darkgreen:[0,100,0],darkkhaki:[189,183,107],darkmagenta:[139,0,139],darkolivegreen:[85,107,47],darkorange:[255,140,0],darkorchid:[153,50,204],darkred:[139,0,0],darksalmon:[233,150,122],darkviolet:[148,0,211],fuchsia:[255,0,255],gold:[255,215,0],green:[0,128,0],indigo:[75,0,130],khaki:[240,230,140],lightblue:[173,216,230],lightcyan:[224,255,255],lightgreen:[144,238,144],lightgrey:[211,211,211],lightpink:[255,182,193],lightyellow:[255,255,224],lime:[0,255,0],magenta:[255,0,255],maroon:[128,0,0],navy:[0,0,128],olive:[128,128,0],orange:[255,165,0],pink:[255,192,203],purple:[128,0,128],violet:[128,0,128],red:[255,0,0],silver:[192,192,192],white:[255,255,255],yellow:[255,255,0]}})(jQuery);
+
+
+function colors(neededColors) {
+
+
+
+	var i;
+ 
+        // produce colors as needed
+        var variation = 0;
+        var colors = [$.color.make(237, 194, 64), 
+		        $.color.make(175, 216, 248), 
+		        $.color.make(203, 75, 75), 
+		        $.color.make(77, 167, 77), 
+		        $.color.make(148, 64, 237)];  
+        i = 0;
+        while (colors.length < neededColors) {
+            var c;
+            if (colors.length == i) // check degenerate case
+                c = $.color.make(100, 100, 100); 
+            else 
+		c = colors[i];
+            // vary color if needed
+            var sign = variation % 2 == 1 ? -1 : 1;
+            c.scale('rgb', 1 + sign * Math.ceil(variation / 2) * 0.2);
+
+            // FIXME: if we're getting to close to something else,
+            // we should probably skip this one
+            colors.push(c);
+                
+            ++i;
+            if (i >= colors.length) {
+                i = 0;
+                ++variation;
+            }
+        }
+
+	return colors; 
+
+     }
+

--- a/static/d3/d3_graph.js
+++ b/static/d3/d3_graph.js
@@ -130,8 +130,8 @@ SimpleGraph = function(elemid, name, options, series, o) {
   this.vis = d3.select(this.chart).append("svg")
       .attr("name_d3graph", name) 
       .attr("width",  this.cx)
-      .attr("height", this.cy)
-      .attr("style", "background-color:white")
+      .attr("height", this.cy + 40)
+      .attr("style", "background-color:white; padding:20px")
       .append("g")
         .attr("transform", "translate(" + this.padding.left + "," + this.padding.top + ")");
 
@@ -172,11 +172,10 @@ SimpleGraph = function(elemid, name, options, series, o) {
         .attr("class", "axis")
         .text(this.options.xlabel)
         .attr("x", this.size.width/2)
-        .attr("y", this.size.height)
+        .attr("y", this.size.height - this.size.width/2 - 20)
         .attr("dy","2.4em")
         .style("text-anchor","middle");
   }
-
   // add y-axis label
   if (this.options.ylabel) {
     this.vis.append("g").append("text")
@@ -498,7 +497,7 @@ SimpleGraph.prototype.redraw = function() {
 			return a;
 		}, String)
 
-        .attr("transform", tx); 
+        .attr("transform", tx);
     gx.select("text")
         .text(fx);
 
@@ -515,16 +514,15 @@ SimpleGraph.prototype.redraw = function() {
         .attr("class", "axis")
         .attr("y", self.size.height)
         .attr("dy", "1em")
-        .attr("text-anchor", "middle")
+        .attr("text-anchor", "start")
         .text(fx)
         .style("cursor", "ew-resize")
         .on("mouseover", function(d) { d3.select(this).style("font-weight", "bold");})
         .on("mouseout",  function(d) { d3.select(this).style("font-weight", "normal");})
         .on("mousedown.drag",  self.xaxis_drag())
-        .on("touchstart.drag", self.xaxis_drag()); 
-//	.attr("transform", function(d) {
-//                return "rotate(20)" 
-//                }); 
+        .on("touchstart.drag", self.xaxis_drag())
+	.attr("transform", function(d) {
+                return "translate(" + 80 + ", " + 30 + ")" + " rotate(12)"});
  
     gx.exit().remove();
 

--- a/static/d3/d3_graph.js
+++ b/static/d3/d3_graph.js
@@ -1,0 +1,593 @@
+$( window ).load(function() {
+  $("#graph1").hide();
+  $("#graph1").css("background-color", "white");
+});
+
+function zip(a, b) {
+
+return a.map(function (e, i) {
+    return [e, b[e]];
+});
+
+
+}
+
+
+function get_max_xy(series) {
+
+  max_x = Math.max.apply(null, series.map(function(x) {return Math.max.apply(null, x.data.map(function(y){return y[0];   })); }));
+ 
+  max_y = Math.max.apply(null, series.map(function(x) {return Math.max.apply(null, x.data.map(function(y){return y[1];
+})); })); 
+ 
+  var xy = [max_x, max_y]; 
+  return xy; 
+
+}
+
+function get_xs(series, args=null) {
+
+var my_set = new Set( 
+([].concat.apply([], series.map(function (d) { return d.data; }))).map(function(xy) {return xy[0]; } 
+)); 
+return my_set; 
+
+}
+
+function d3_graph(graph, series, options, o, name="default") {
+
+xaxis_label = options.xaxis.axisLabel;  
+yaxis_label = $("span[class='som_name']").text();
+$("[name_d3graph='default']").remove(); //remove the old svgs
+$("[class='tooltip']").remove();  
+
+// keep only elements that contain useful information for the graph
+series = series.filter(function (x) {return !('lines' in x)});
+
+// sort x elements in each line/
+series = series.map(function (x) {x.data.sort(function(a, b){return a[0]-b[0]}); return x});  
+xyz = get_max_xy(series); //get max x and max y in the xyz array 
+
+
+
+ graph = new SimpleGraph("graph1",name, {
+          "xmax": xyz[0], "xmin": 0,
+          "ymax": xyz[1], "ymin": 0, 
+          "title": "Simple Graph1",
+          "xlabel": xaxis_label, 
+        "ylabel": yaxis_label  
+        }, series, o);
+}; 
+
+registerKeyboardHandler = function(callback) {
+  var callback = callback;
+  d3.select(window).on("keydown", callback);  
+};
+
+SimpleGraph = function(elemid, name, options, series, o) {
+
+
+  if ($("#graph1").is(":hidden")) {     //if you click on the btn "redraw" while #graph1 is hidden, it won't redraw #graph1. Then if redraw is called while #graph1 
+			                //is hidden, it first show, redraw and then hide again at the end of this function
+	$("#graph1").show();
+	var will_hide = 1; 
+
+} 
+
+  var self = this;
+  this.o = o; 
+  this.color = colors(series.length);
+  this.series = series; 
+  this.chart = document.getElementById(elemid);
+  this.cx = this.chart.clientWidth;
+  this.cy = this.chart.clientHeight; 
+  this.options = options || {};
+  this.options.xmax = options.xmax || 30;
+  this.options.xmin = options.xmin || 0;
+  this.options.ymax = options.ymax || 10;
+  this.options.ymin = options.ymin || 0;
+
+  this.padding = {
+     "top":    this.options.title  ? 40 : 20,
+     "right":                 30,
+     "bottom": this.options.xlabel ? 60 : 10,
+     "left":   this.options.ylabel ? 70 : 45
+  };
+
+  this.size = {
+    "width":  this.cx - this.padding.left - this.padding.right,
+    "height": this.cy - this.padding.top  - this.padding.bottom
+  };
+
+  // x-scale
+  this.x = d3.scale.linear()
+      .domain([this.options.xmin, this.options.xmax])
+      .range([0, this.size.width]);
+  // drag x-axis logic
+  this.downx = Math.NaN;
+
+  // y-scale (inverted domain)
+  this.y = d3.scale.linear()
+      .domain([this.options.ymax, this.options.ymin])
+      .nice()
+      .range([0, this.size.height])
+      .nice();
+
+  // drag y-axis logic
+  this.downy = Math.NaN;
+
+  //this.dragged = this.selected = null;
+
+  this.line = d3.svg.line()
+      .x(function(d, i) { return self.x(d[0]); })
+      .y(function(d, i) { return self.y(d[1]); });
+
+  var xrange =  (this.options.xmax - this.options.xmin),
+      yrange2 = (this.options.ymax - this.options.ymin) / 2,
+      yrange4 = yrange2 / 2,
+      datacount = this.size.width/30;
+
+  this.vis = d3.select(this.chart).append("svg")
+      .attr("name_d3graph", name) 
+      .attr("width",  this.cx)
+      .attr("height", this.cy)
+      .attr("style", "background-color:white")
+      .append("g")
+        .attr("transform", "translate(" + this.padding.left + "," + this.padding.top + ")");
+
+  this.plot = this.vis.append("rect")
+      .attr("id", "graph1_rect")
+      .attr("width", this.size.width)
+      .attr("height", this.size.height)
+      .style("fill", "#fff")
+      .attr("pointer-events", "all")
+      //.on("mousedown.drag", self.plot_drag())
+      //.on("touchstart.drag", self.plot_drag())
+
+
+      this.plot.call(d3.behavior.zoom().x(this.x).y(this.y).on("zoom", this.redraw()));
+
+
+  this.vis.append("svg")
+      .attr("top", 0)
+      .attr("left", 0)
+      .attr("width", this.size.width)
+      .attr("height", this.size.height)
+      .attr("viewBox", "0 0 "+this.size.width+" "+this.size.height)
+      .selectAll(".line")
+      .data(this.series)
+      .enter()
+      .append("path")
+          .attr("class", "line")
+	  .attr("fill", "none") 
+          .attr("stroke-width", 0)
+          .attr("stroke", function(d) { return self.color[d.color] })
+          .attr("d", function(d) { return self.line(d.data)} )	
+
+	  // add Chart Title
+
+  // Add the x-axis label
+  if (this.options.xlabel) {
+    this.vis.append("text")
+        .attr("class", "axis")
+        .text(this.options.xlabel)
+        .attr("x", this.size.width/2)
+        .attr("y", this.size.height)
+        .attr("dy","2.4em")
+        .style("text-anchor","middle");
+  }
+
+  // add y-axis label
+  if (this.options.ylabel) {
+    this.vis.append("g").append("text")
+        .attr("class", "axis")
+        .text(this.options.ylabel)
+        .style("text-anchor","middle")
+        .attr("transform","translate(" + -40 + " " + this.size.height/2+") rotate(-90)");
+  }
+
+  d3.select(this.chart)
+      .on("mousemove.drag", self.mousemove())
+      .on("touchmove.drag", self.mousemove())
+      .on("mouseup.drag",   self.mouseup())
+      .on("touchend.drag",  self.mouseup());
+
+  this.redraw()();
+
+  if (will_hide == 1) 
+  $("#graph1").hide(); 
+  will_hide = 0; 
+
+};
+  
+
+// SimpleGraph methods
+
+SimpleGraph.prototype.update = function() {
+  var self = this; 
+  var clicked = true; 
+  var tt_div = d3.select("body").append("div")
+    .attr("class", "tooltip")
+    .style("display", "none")
+    .style("opacity", 0)
+    .style("width", "270px")
+    .style("height", "200px");
+
+  var lines = this.vis
+      .selectAll(".line")
+      .data(this.series)
+      .attr("stroke-width", 2)
+      .attr("d", function(d) { return self.line(d.data)}); 
+
+
+  var circle = this.vis.select("svg").selectAll("circle")
+      .data([].concat.apply([], this.series.map(function (d) {
+        return d.data.map(function(pos){ pos[3] = d.color; return pos;});
+      })))
+
+  circle.enter().append("circle")
+      .attr("class", function(d) { return d === self.selected ? "selected" : null; })
+      .attr("cx",    function(d) { return self.x(d[0]); })
+      .attr("cy",    function(d) { return self.y(d[1]); })
+      .attr("r", 5.0)
+      .style("cursor", "ns-resize")
+      .style("fill", function(d) { return self.color[d[3]]; });
+	
+  var is_img = 0; 
+
+  circle
+      .attr("class", function(d) { return d === self.selected ? "selected" : null; })
+      .attr("cx",    function(d) { return self.x(d[0]); })
+      .attr("cy",    function(d) { return self.y(d[1]); })
+      .on("mouseover", function(d) {
+ 		tt_div.transition()
+                   .duration(100)
+		   .style("display", "inline")
+                   .style("opacity", 0.85)
+                   .style("left", (d3.event.pageX + 3) + "px")
+                   .style("top", (d3.event.pageY + 3) + "px");      
+		
+		tt_div 
+			.html("<table class=\"center_item\">" + 
+				"<tr><td>" + "x" + "</td><td>" + "</td><td>" + d[0] + "</td></tr>" + 
+				"<tr><td>" + "y" + "</td><td>" + "</td><td>" + d[1] + "</td></tr>" + 
+				generate_metadata(d[2]));
+		tt_div 
+			.style("background-color", function(n) { return self.color[d[3]]; });
+		totalHeight = 0;
+		totalWidth = 0;
+		$(".tooltip").children("table").children("tbody").children("tr").each(function(i) {
+		totalHeight= totalHeight + $(this).height(); 
+		});
+		totalWidth = $(".tooltip").children("table").children("tbody").children("tr").width();
+
+		if (totalHeight > $(".tooltip").height() && totalHeight != 0) { //adjust tooltip height if there are many elements
+		
+		$(".tooltip").css("height", (totalHeight + 40) + "px");
+
+		}
+		if (totalWidth > $(".tooltip").width() && totalWidth != 0) {
+
+		$(".tooltip").css("width", (totalWidth + 20) + "px");
+
+		}
+
+		
+		if (totalHeight < $(".tooltip").height() && totalHeight != 0) { 
+		
+		$(".tooltip").css("height", (totalHeight + 70) + "px");
+
+		}
+		if (totalWidth < $(".tooltip").width() && totalWidth != 0) {
+
+		$(".tooltip").css("width", (totalWidth + 20) + "px");
+
+		}
+
+		tt_div.on("click", function(d) {
+
+				
+			var close_img = tt_div.append("div");
+			is_img = 1; 
+			close_img.html("<img src='close.png'>").on("click", function(d) {
+
+				tt_div.style("opacity", 0);
+				is_img = 0; 
+				
+			}); 
+
+		}) 
+
+ })
+
+      .on("click", function(d) {
+	
+	tt_div.style("opacity", 0.85)
+	var close_img = tt_div.append("div");
+	is_img = 1; 
+	close_img.html("<img src='close.png'>").on("click", function(d) {
+
+		tt_div.style("opacity", 0);
+		is_img = 0; 
+				
+	}); 
+
+})
+
+
+	.on("mouseout", function(d) {
+		
+		if (is_img == 0) {
+		tt_div.style("opacity", 0);
+		}
+
+	}); 
+
+
+
+function generate_metadata(metadata) {
+    
+    var body = ""; 
+    for (var i in metadata) {
+      var kv = metadata[i];
+
+	body += "<tr><td>" + i + "</td><td>" + "</td>" + "<td>" + kv + "</td></tr>";  
+    }
+
+    body += "</table>"; 
+    return body;
+  } 
+
+ 
+
+  circle.exit().remove();
+
+  if (d3.event && d3.event.keyCode) {
+    d3.event.preventDefault();
+    d3.event.stopPropagation();
+  }
+}; 
+
+SimpleGraph.prototype.datapoint_drag = function(index) { //update points position while moving the graph 
+  var self = this;
+  return function(d) {
+    registerKeyboardHandler(self.keydown());
+    document.onselectstart = function() { return false; };
+    self.selected = self.dragged = d;
+    self.update();  
+  }
+};
+
+SimpleGraph.prototype.mousemove = function(index) {
+  var self = this;
+  return function() {
+    var p = d3.svg.mouse(self.vis[0][0]),
+        t = d3.event.changedTouches;
+    
+    if (self.dragged) {
+     // self.dragged.y = self.y.invert(Math.max(0, Math.min(self.size.height, p[1])));
+      self.update();
+    };
+    if (!isNaN(self.downx)) {
+      d3.select('body').style("cursor", "ew-resize");
+      var rupx = self.x.invert(p[0]),
+          xaxis1 = self.x.domain()[0],
+          xaxis2 = self.x.domain()[1],
+          xextent = xaxis2 - xaxis1;
+      if (rupx != 0) {
+        var changex, new_domain;
+        changex = self.downx / rupx;
+        new_domain = [xaxis1, xaxis1 + (xextent * changex)];
+        self.x.domain(new_domain);
+        self.redraw()();
+      }
+      d3.event.preventDefault();
+      d3.event.stopPropagation();
+    };
+    if (!isNaN(self.downy)) {
+      d3.select('body').style("cursor", "ns-resize");
+      var rupy = self.y.invert(p[1]),
+          yaxis1 = self.y.domain()[1],
+          yaxis2 = self.y.domain()[0],
+          yextent = yaxis2 - yaxis1;
+      if (rupy != 0) {
+        var changey, new_domain;
+        changey = self.downy / rupy;
+        new_domain = [yaxis1 + (yextent * changey), yaxis1];
+        self.y.domain(new_domain);
+        self.redraw()();
+      }
+      d3.event.preventDefault();
+      d3.event.stopPropagation();
+    }
+  }
+};
+
+SimpleGraph.prototype.mouseup = function() {
+  var self = this;
+  return function() {
+    document.onselectstart = function() { return true; };
+    d3.select('body').style("cursor", "auto");
+    d3.select('body').style("cursor", "auto");
+    if (!isNaN(self.downx)) {
+      self.redraw()();
+      self.downx = Math.NaN;
+      d3.event.preventDefault();
+      d3.event.stopPropagation();
+    };
+    if (!isNaN(self.downy)) {
+      self.redraw()();
+      self.downy = Math.NaN;
+      d3.event.preventDefault();
+      d3.event.stopPropagation();
+    }
+    if (self.dragged) { 
+      self.dragged = null 
+    }
+  }
+}
+
+SimpleGraph.prototype.redraw = function() {
+
+  var will_hide = 0; 
+
+  var self = this;
+  
+  $("[class='tooltip']").remove();
+
+  $("div[id='legend_container']").remove();
+  
+  d3.select("#graph1")
+	.append("div")
+	.attr("id", "legend_container")
+	.attr("width", "200px")
+	.attr("height", "50px")
+
+  d3.select("#legend_container")
+	.append("table")
+	.attr("id", "legend_table")
+	.attr("cellspacing", "9");
+
+  for (var i=0; i < self.series.length; i++) {	
+		
+		var table_tr = d3.select("#legend_table").append("tr");  
+		table_tr.append("td").attr("style", function(d) {return "background-color:" + self.color[self.series[i].color] + ";";}).append("div").attr("style", "width:2em");
+
+		table_tr.append("td").attr("class", "a30x100").append("div")
+
+			.attr("style", "width:960px; white-space: initial;overflow: hidden;text-overflow: ellipsis; word-wrap:break-word")
+			.text(self.series[i].label);
+			
+		
+}
+
+  if (typeof(this.o.x_labels) != "undefined") {
+
+    var fx_label = function(d) { return d[1]; };
+
+  } else {
+
+	var fx_label = function(d) { return self.x.tickFormat(10)(d[0]) };
+
+  }
+
+  return function() {
+    var tx = function(d) {
+      return "translate(" + self.x(d[0]) +  ",0)"; 
+    },
+    ty = function(d) { 
+      return "translate(0," + self.y(d) + ")";
+    },
+    stroke = function(d) { 
+      return d ? "#ccc" : "#666"; 
+    },
+
+    fx = fx_label, 
+    fy = self.y.tickFormat(10);
+
+	var count = 0; 
+
+    // Regenerate x-ticks…
+    var xs = get_xs(self.series);  
+    var gx = self.vis.selectAll("g.x")
+        .data(function(d) {
+			xs_ary = Array.from(xs.values());
+			if (typeof(self.o.x_labels) != "undefined")
+				a =  zip(xs_ary,self.o.x_labels);
+			else a = zip(self.x.ticks(xs.size),self.x.ticks(xs.size))
+			return a;
+		}, String)
+
+        .attr("transform", tx); 
+    gx.select("text")
+        .text(fx);
+
+    var gxe = gx.enter().insert("g", "a")
+        .attr("class", "x")
+        .attr("transform", tx);
+
+    gxe.append("line")
+        .attr("stroke", stroke)
+        .attr("y1", 0)
+        .attr("y2", self.size.height);
+
+    gxe.append("text")
+        .attr("class", "axis")
+        .attr("y", self.size.height)
+        .attr("dy", "1em")
+        .attr("text-anchor", "middle")
+        .text(fx)
+        .style("cursor", "ew-resize")
+        .on("mouseover", function(d) { d3.select(this).style("font-weight", "bold");})
+        .on("mouseout",  function(d) { d3.select(this).style("font-weight", "normal");})
+        .on("mousedown.drag",  self.xaxis_drag())
+        .on("touchstart.drag", self.xaxis_drag()); 
+//	.attr("transform", function(d) {
+//                return "rotate(20)" 
+//                }); 
+ 
+    gx.exit().remove();
+
+    // Regenerate y-ticks…
+    var gy = self.vis.selectAll("g.y")
+        .data(self.y.ticks(10), String)
+        .attr("transform", ty);
+
+    gy.select("text")
+        .text(fy);
+
+    var gye = gy.enter().insert("g", "a")
+        .attr("class", "y")
+        .attr("transform", ty)
+        .attr("background-fill", "#FFEEB6");
+
+    gye.append("line")
+        .attr("stroke", stroke)
+        .attr("x1", 0)
+        .attr("x2", self.size.width);
+
+    gye.append("text")
+        .attr("class", "axis")
+        .attr("x", -3)
+        .attr("dy", ".35em")
+        .attr("text-anchor", "end")
+        .text(fy)
+        .style("cursor", "ns-resize")
+        .on("mouseover", function(d) { d3.select(this).style("font-weight", "bold");})
+        .on("mouseout",  function(d) { d3.select(this).style("font-weight", "normal");})
+        .on("mousedown.drag",  self.yaxis_drag())
+        .on("touchstart.drag", self.yaxis_drag());
+
+    gy.exit().remove();
+    self.plot.call(d3.behavior.zoom().x(self.x).y(self.y).on("zoom", self.redraw()));
+    self.update();      
+  }
+
+	if (will_hide == 1) {
+
+	$("#graph1").hide();
+	will_hide = 0;
+
+}
+  
+}
+
+SimpleGraph.prototype.xaxis_drag = function() {
+  var self = this;
+  return function(d) {
+    document.onselectstart = function() { return false; };
+    var p = d3.svg.mouse(self.vis[0][0]);
+    self.downx = self.x.invert(p[0]);
+  }
+};
+
+SimpleGraph.prototype.yaxis_drag = function(d) {
+  var self = this;
+  return function(d) {
+    document.onselectstart = function() { return false; };
+    var p = d3.svg.mouse(self.vis[0][0]);
+    self.downy = self.y.invert(p[1]);
+  }
+
+}; 
+ 

--- a/static/d3/d3_graph.js
+++ b/static/d3/d3_graph.js
@@ -455,11 +455,18 @@ SimpleGraph.prototype.redraw = function() {
 		table_tr.append("td").attr("class", "a30x100").append("div")
 
 			.attr("style", "width:960px; white-space: initial;overflow: hidden;text-overflow: ellipsis; word-wrap:break-word")
-			.text(self.series[i].label);
-			
-		
-}
+			.html(function(d) {
+				var coma_split = self.series[i].label.split(",");
+				var equal_split = coma_split.map(function(n) {return n.split("=");});
+				var html = "";
+				for (var j=0; j < equal_split.length; ++j) {
 
+					html += "<strong>" + equal_split[j][0] + "</strong>" + "=" + equal_split[j][1] + ", ";
+
+				}
+				return html;
+			});
+}
   if (typeof(this.o.x_labels) != "undefined") {
 
     var fx_label = function(d) { return d[1]; };

--- a/static/header.html
+++ b/static/header.html
@@ -16,6 +16,9 @@
   <script language="javascript" type="text/javascript" src="flot/jquery.flot.symbol.js"></script>
   <script language="javascript" type="text/javascript" src="base64.js"></script>
   <script language="javascript" type="text/javascript" src="tablesorter/jquery.tablesorter.js"></script>
+  <script language="javascript" type="text/javascript" src="https://d3js.org/d3.v2.min.js"></script>
+  <script language="javascript" type="text/javascript" src="d3/d3_graph.js"></script>
+  <script language="javascript" type="text/javascript" src="d3/d3_color.js"></script>
  </head>
  <body>
   <div class="title">

--- a/static/rage.js
+++ b/static/rage.js
@@ -806,3 +806,21 @@ function on_async_fail(XMLHttpRequest, textStatus, errorThrown) {
   console.log(errorThrown);
 }
 
+function change_graph() {
+
+        var sel_value = $("#graph_option").val();
+
+        if (sel_value == "d3") {
+                $(".graph_container").css("display", "none");
+                $("#graph1").css("display", "block");
+
+        }
+        else if (sel_value == "flot") {
+
+                $("#graph1").css("display", "none");
+                $(".graph_container").css("display", "block");
+
+        }
+
+}
+

--- a/static/rage.js
+++ b/static/rage.js
@@ -717,6 +717,7 @@ function GraphObject() {
     }
     $("#stop_plotting").prop("disabled", false);
     var start = new Date();
+    d3_graph(graph, series, options, o);
     flot_object = $.plot(graph, series, options, function() {
       console.log("Plotting took " + (new Date() - start) + "ms.");
       // click

--- a/static/style.css
+++ b/static/style.css
@@ -290,3 +290,20 @@ a {
   margin:auto;
   width:100%;
 }
+
+.chart {
+        background-color: #F7F2C5;
+        width: 960px;
+        height: 500px; }
+
+circle {
+        circle.selected {
+          fill: #ff7f0e;
+          stroke: #ff7f0e; }
+        circle:hover {
+          fill: #ff7f0e;
+          stroke: #707f0e; }
+        circle.selected:hover {
+          fill: #ff7f0e;
+          stroke: #ff7f0e; }
+


### PR DESCRIPTION
Originally rage had a static graph based on the Flot library. 
This pull request adds a new zoomable dynamic graph based on the D3 library. 

A new switch besides the draw button lets you choose between the Flot and the D3 graph. 
