### PR TITLE
Add filtering to brief report

### DIFF
--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -1005,12 +1005,22 @@ let t ~args = object (self)
       printf "%s" "<li> (x) indicates number of samples\n";
       printf "%s" "<li> (x%) indicates difference with baseline column\n";
       printf "%s" "<li> [lower, avg, upper] indicates [avg-2*stddev, avg, avg+2*stddev]. If relative standard error < 5%, only avg is shown.</ul>\n";
+      printf "<h4 style='margin:5px'>Filtering</h4>";
+      printf "<input name='filterEnabled' value='filtered' type='checkbox'>";
+      printf "<label for='filterEnabled'>Show";
+      printf "<select name='filterType'> 
+                <option value='regressions'>only regressions</option> 
+                <option value='all'>all rows</option>
+              </select> >= ";
+      printf "<input name='minRegression' type='number' value='5' style='width:4em'>%%</label>";
       printf "<table>%s</table>" html_table;
       let page_finish_time = Unix.gettimeofday () in
       printf "<hr/>\n";
       printf "<p>Report contained <b>%d rows</b> and took <b>%f seconds</b> to prepare</p>"
         (List.length table)
-        (page_finish_time -.  page_start_time)
+        (page_finish_time -.  page_start_time);
+      (* Javascript *)
+      printf "<script src='ragebrief.js'></script>";
     in
 
     let wiki_writer table =

--- a/static/ragebrief.js
+++ b/static/ragebrief.js
@@ -1,0 +1,83 @@
+// Include this at the end of body, so DOM is loaded
+
+// First 3 rows are fixed text (product, titles, comparison) - all the rest are data
+const rows = Array.from(document.querySelector('table').querySelectorAll('tr'));
+rows.splice(0,3);
+
+// Helper methods for filter code
+const normalise = s =>
+  // Normalise a cell value like (-7%) to 7, like (3%) to 3
+  parseInt(s.replace('(', '').replace('%)', '').replace('-', '').replace('+', ''), 10);
+
+const is_cell_empty = cell => 
+  // If empty then the text content starts with a - followed by a space (as opposed to a negative number)
+  cell.textContent.trim().startsWith('- ');
+
+const is_last_cell_empty = row =>
+  is_cell_empty(row.lastElementChild);
+
+const is_row_green = row =>
+  row.lastElementChild.querySelector('div span').style.color == 'green';
+
+const showAllRows = () => rows.map(row => row.style.display = '');
+
+const getSelectValue = (s) => s.options[s.selectedIndex].value;
+
+function hideNonInterestingRows(regressionsOnly=true, threshold=5){
+  for(var i=0; i<rows.length; i++){
+    const row = rows[i];
+
+    // Filter empty last row
+    if(is_last_cell_empty(row)){
+      row.style.display = 'none';
+      continue;
+    }
+
+    // Filter non-regressions if required
+    if(regressionsOnly && is_row_green(row)){
+      row.style.display = 'none';
+      continue
+    }
+
+    const last_cell = row.lastElementChild;
+    const subs = last_cell.querySelector('div').querySelectorAll('sub');
+    // Filter if no % in the last cell
+    if(subs.length == 1){
+      row.style.display = 'none';
+      continue;
+    }
+
+    // second sub is the %
+    const normalised_percentage = normalise(subs[1].innerHTML);
+    if(normalised_percentage < threshold){
+      row.style.display = 'none'; 
+      continue;
+    }
+  }
+}
+
+// DOM elements for filter UI
+const filterEnabled = document.querySelector('input[name=filterEnabled]');
+const filterType = document.querySelector('select[name=filterType]');
+const minRegression = document.querySelector('input[name=minRegression]');
+
+// DOM event for filtering (e is event, unused)
+const filter = (e) => {
+  if(!filterEnabled.checked){
+    showAllRows();
+    return;
+  }
+
+  const regressionsOnly = getSelectValue(filterType) === "regressions";  
+
+  const threshold = parseInt(minRegression.value);
+  showAllRows(rows);
+  hideNonInterestingRows(regressionsOnly, threshold);
+};
+
+filterEnabled.onchange = filter;
+filterType.onchange = filter;
+minRegression.oninput = filter;
+
+// Run the filter on page load too
+filter({});


### PR DESCRIPTION
This commit adds a basic filtering capability to the brief report, based on the % of the right-most column (assumed to be the build under review). It can show/hide rows, based on a configurable (by a HTML input) threshold, the minimum % to consider. This defaults to 5%, which should reduce noise. We can also configure whether to show only regressions or also improvements.

Implementation:
- A new javascript ragebrief.js is included in static, included by the brief report HTML writer.
- The new inputs are added above the brief report table
- All inputs use immediate change handlers, we re-filter the table every time any of them change

Performance: The filtering is quite naive, we show all rows and then hide those that need hiding. I've tested this with a recent report with many rows/columns, and it's fast enough to be instant. If needed I can add some intelligence in future but for now this works well.

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>