### PR TITLE
Add graph presets

### DIFF
--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -868,6 +868,7 @@ let t ~args = object (self)
     in
     let link_ctxs = (List.map (sort_table measurements_of_table) ~f:(fun (r,cs)->link_ctx_of_row (List.concat (List.map cs ~f:(fun (_,_,ctx,_)->ctx))))) in
     let link_xaxis = List.dedup (List.concat (List.map cs ~f:(fun c-> List.map c ~f:(fun (x,_)->x)))) in
+    let link_xaxis = List.filter link_xaxis ~f:(fun x -> x <> "label") in
 
 
     (* writers *)

--- a/src/som_page_handler.ml
+++ b/src/som_page_handler.ml
@@ -132,6 +132,10 @@ let t ~args = object (self)
     printf "<table width=\"100%%\" border=\"0\">\n<tr><td>\n";
     self#write_som_info som_info;
     print_select_list ~label:"View" ~attrs:[("id", "view")] ["Graph"; "Table"];
+    printf "<br><br>";
+    printf "<b>Presets:</b>";
+    printf "<input value='Brief report analysis' id='preset-brief' type='button'>";
+    printf "<br>";
     printf "<div id='axes_selectors'>";
     print_x_axis_choice ~conn config_columns som_configs_opt;
     print_y_axis_choice ~conn config_columns som_configs_opt;

--- a/static/rage.js
+++ b/static/rage.js
@@ -825,3 +825,52 @@ function change_graph() {
 
 }
 
+// Presets
+function _setSelected(sel, val, selected){
+    options = Array.from($(`select[name=${sel}] option`));
+    for(var i=0; i<options.length; i++){
+        option = options[i];
+        if(option.value == val){
+            option.selected = selected;
+            break;
+        }
+    }
+    $(`select[name=${sel}`).trigger('change');
+}
+
+const unselect = (sel, val) => _setSelected(sel, val, false);
+const select = (sel, val) => _setSelected(sel, val, true);
+const unselectAll = (sel) => {
+    Array.from($(`select[name=${sel}] option`)).map(opt => opt.selected = false); 
+    $(`select[name=${sel}`).trigger('change');
+};
+
+const setPresetBriefReport = () => {
+    // unselect build tag, select build date
+    unselect('xaxis', 'build_tag');
+    select('xaxis', 'build_date');
+
+    // select master
+    select('v_branch', 'master');
+
+    // split by branch
+    select('f_branch', 1); // 0=show for, 1=split by
+
+    // Select 'All' build number
+    unselectAll('v_build_number');
+    select('v_build_number', 'ALL');
+
+    // Select 'All' build tag
+    unselectAll('v_build_tag');
+    select('v_build_tag', 'ALL');
+
+    // Select SW legend position, our interesting data is usually NE
+    select('legend_position', 'sw');
+
+    // Enable autodraw - jquery to trigger its jquery change event
+    $('input[name=auto_redraw]').prop('checked', true);
+    redraw_graph();
+};
+
+// Set the preset brief report analysis button to call the setPresetBriefReport method
+document.querySelector('#preset-brief').addEventListener('click', (e) => setPresetBriefReport())


### PR DESCRIPTION
When we analyse brief reports there are a series of steps we always take to produce a graph more useful than the generated graph link. This PR adds a button "Brief report analysis" which automatically performs these actions:

    - Unselect build tag, select build date
    - Select master branch
    - Split by branch
    - Select all build numbers
    - Select all build tags
    - Move the legend to bottom left
    - Enable auto redraw
    - Draw the graph

The building blocks are very simple functions `select`, `unselect`, `unselectAll`, which should make it trivial to build further presets in the future.

--

I've also included the commit to filter the label from xaxis when we generate graph links, so we can use that in future reports.