### PR TITLE
Automatically use brief report analysis options based on URL

### DIFF
--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -905,7 +905,7 @@ let t ~args = object (self)
           (
           (* rage is not generic enough to receive an arbirary number of soms in a link, pick just the first one *)
           let som_id=match List.find_exn ctx ~f:(fun (k,_)->k="soms") with |(k,v)->List.hd_exn v in
-          (sprintf "<a href='http://%s/?som=%s&show_dist=on%s%s'>graph</a>" (Utils.server_name ()) som_id
+          (sprintf "<a href='http://%s/?som=%s&show_dist=on%s%s#brief_report_analysis'>graph</a>" (Utils.server_name ()) som_id
             (* xaxis *)
             (List.fold_left link_xaxis ~init:"" ~f:(fun acc x->sprintf "%s%s" acc (sprintf "&xaxis=%s" x)))
             (* preset values *)
@@ -1000,7 +1000,7 @@ let t ~args = object (self)
        ))
       )
       in
-      let brief_name = if is_digit brief_id then "jim #"^brief_id else sprintf "from <a href='%s'>%s</a>" brief_id brief_id in
+      let brief_name = if is_digit brief_id then "jim #"^brief_id else sprintf "from <a href='%s#brief_report_analysis'>%s</a>" brief_id brief_id in
       printf "<p>Brief RAGE Report %s: <b>%s</b></p>\n" brief_name (title_of_id brief_id);
       printf "%s" "<ul><li> Numbers reported at 95% confidence level from the data of existing runs\n";
       printf "%s" "<li> (x) indicates number of samples\n";

--- a/static/rage.js
+++ b/static/rage.js
@@ -874,3 +874,7 @@ const setPresetBriefReport = () => {
 
 // Set the preset brief report analysis button to call the setPresetBriefReport method
 document.querySelector('#preset-brief').addEventListener('click', (e) => setPresetBriefReport())
+
+if(location.hash == '#brief_report_analysis'){
+    setPresetBriefReport();
+}


### PR DESCRIPTION
Adds javascript to check the `location.hash`, so that if #brief_report_analysis is appended to the URL it will automatically apply the brief report preset options.
Modify graph links produced by the brief report to append #brief_report_analysis

Note: I used a # instead of an extra get parameter because the tiny URL ignores the hash - which makes sense because it's already set all the options in the preset so it doesn't need to remember it. It's also only used client-side.

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>