### PR TITLE
[CP-27369] Add host_type to tc configs

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -105,6 +105,7 @@ create table tc_config (
   cpufreq_governor varchar(32) not null,
   dom0_vcpus integer not null,
   host_pcpus integer not null,
+  host_type varchar(16) not null,
 
   foreign key (job_id) references jobs(job_id),
   foreign key (tc_fqn) references test_cases(tc_fqn),

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -215,6 +215,7 @@ let tc_config_fields = [
   "dom0_vcpus";
   "host_pcpus";
   "live_patching";
+  "host_type";
 ]
 
 let build_fields = [


### PR DESCRIPTION
host_type is a new field in `tc_configs` table, which differentiates physical from nested_virt test cases.

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>