### PR TITLE
Add report quality metrics to the brief report

### DIFF
--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -1010,7 +1010,10 @@ let t ~args = object (self)
       printf "%s" "<ul><li> Numbers reported at 95% confidence level from the data of existing runs\n";
       printf "%s" "<li> (x) indicates number of samples\n";
       printf "%s" "<li> (x%) indicates difference with baseline column\n";
-      printf "%s" "<li> [lower, avg, upper] indicates [avg-2*stddev, avg, avg+2*stddev]. If relative standard error < 5%, only avg is shown.</ul>\n";
+      printf "%s" "<li> [lower, avg, upper] indicates [avg-2*stddev, avg, avg+2*stddev]. If relative standard error < 5%, only avg is shown.</ul><br>";
+      printf "<h4 style='margin:5px'>Report Quality</h4>";
+      printf "Rows with data in last column: <span style='font-weight:bold' id='report_quality_data_last'></span><br>";
+      printf "Rows with data in 2nd-to-last, but not last: <span style='font-weight:bold' id='report_quality_missing_data_last'></span><br><br>";
       printf "<h4 style='margin:5px'>Filtering</h4>";
       printf "<input name='filterEnabled' value='filtered' type='checkbox'>";
       printf "<label for='filterEnabled'>Enable filtering</label>";

--- a/static/ragebrief.js
+++ b/static/ragebrief.js
@@ -5,6 +5,8 @@ const allRows = Array.from(document.querySelector('table').querySelectorAll('tr'
 const rows = Array.from(allRows);
 rows.splice(0,3);
 
+const num_tds = rows[0].querySelectorAll('td').length
+
 // Augment elements with a remove method
 Element.prototype.remove = function() {
     this.parentElement.removeChild(this);
@@ -132,3 +134,15 @@ filter({});
 const freezeButton = document.querySelector("#freeze_frozen input[type='button']");
 if(freezeButton != null)
   freezeButton.addEventListener('click', () => freeze());
+
+// Populate the row with/without data counts
+// Count rows where the last cell is not empty (ie has data)
+const data_in_last = rows.filter(row => !isCellEmpty(row.querySelectorAll('td')[num_tds-1])).length
+document.getElementById('report_quality_data_last').innerHTML = data_in_last
+
+// Count rows where the last cell is empty *and* the cell before it is not (suggests missing data)
+const missing_in_last = rows.filter(row => {
+  tds = row.querySelectorAll('td')
+  return isCellEmpty(tds[num_tds-1]) && !isCellEmpty(tds[num_tds-2])
+}).length
+document.getElementById('report_quality_missing_data_last').innerHTML = missing_in_last


### PR DESCRIPTION
This commit adds two metrics to the brief report: Rows with data in last column, and rows with data in 2nd-to-last, but not last. This is a good indication of the quality of the data in the build being analysed (the last one in the table) against previous builds - if there are many rows with data in the previous build but not the last then tests are probably still ongoing.

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>